### PR TITLE
Fix unclosed parenthesis in Package-Requires

### DIFF
--- a/elx.el
+++ b/elx.el
@@ -9,7 +9,7 @@
 ;; Homepage: https://github.com/emacscollective/elx
 ;; Keywords: docs libraries packages
 
-;; Package-Requires: ((emacs "25.1") (compat "28.1.1.0")
+;; Package-Requires: ((emacs "25.1") (compat "28.1.1.0"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
The parentheses in `Package-Requires` is not closed, so I'm sending a PR to fix it.
